### PR TITLE
Show versions with numbers > 9 and sort version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -4,52 +4,54 @@ set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
 die () {
-    echo $1
+    echo "$1"
     exit 1
 }
 
 get_download_file_path() {
-    local install_type=$1
-    local version=$2
-    local tmp_download_dir=$3
+    local install_type="$1"
+    local version="$2"
+    local tmp_download_dir="$3"
 
-    local pkg_name="swi-prolog-${install_type}-${version}.tar.gz"
+    local pkg_name="swi-prolog-$install_type-$version.tar.gz"
 
     echo "$tmp_download_dir/$pkg_name"
 }
 
 download_source_file() {
-    local install_type=$1
-    local version=$2
-    local download_path=$3
-    local download_url="http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz"
+    local install_type="$1"
+    local version="$2"
+    local download_path="$3"
+    local download_url="http://www.swi-prolog.org/download/stable/src/swipl-$version.tar.gz"
 
     # if devel suffix in version we install from development channel
-    if [[ $version =~ .*-devel ]]
+    if [[ "$version" =~ .*-devel ]]
     then
         # remove the -devel suffix from version
         download_url="http://www.swi-prolog.org/download/devel/src/swipl-${version%-devel}.tar.gz"
     fi
 
-    curl --fail -Lo $download_path $download_url || die "error fetching ${download_url}"
+    curl --fail -Lo "$download_path" "$download_url" || die "error fetching $download_url"
 }
 
 install_prolog() {
-    local install_type=$1
-    local version=$2
-    local install_path=$3
-    local tmp_download_dir=$(mktemp -dt swi-prolog_build_XXXXXX)
+    local install_type="$1"
+    local version="$2"
+    local install_path="$3"
+    local tmp_download_dir
+    tmp_download_dir="$(mktemp -dt swi-prolog_build_XXXXXX)"
 
-    local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
+    local source_path
+    source_path="$(get_download_file_path "$install_type" "$version" "$tmp_download_dir")"
 
-    download_source_file $install_type $version $source_path
+    download_source_file "$install_type" "$version" "$source_path"
 
     (
-        tar zxf $source_path -C $install_path --strip-components=1 || die "error untaring $source_path"
-        cd $install_path
+        tar zxf "$source_path" -C "$install_path" --strip-components=1 || die "error untaring $source_path"
+        cd "$install_path"
 
         ./configure \
-            --prefix=$install_path \
+            --prefix="$install_path" \
             --with-world \
             --without-jpl \
             --without-xpce \
@@ -59,4 +61,4 @@ install_prolog() {
     )
 }
 
-install_prolog $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_prolog "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -11,7 +11,7 @@ get_devel_versions_page() {
 }
 
 function extract_versions_numbers() {
-    grep -o 'swipl-\([0-9]\.[0-9]\.[0-9]\)' | sed 's/swipl-//'
+    grep -o 'swipl-\([0-9]\+\.[0-9]\+\.[0-9]\+\)' | sed 's/swipl-//'
 }
 
 append_devel_tag() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,11 +3,11 @@ releases_path=http://www.swi-prolog.org/download/stable/src/
 devel_releases_path=http://www.swi-prolog.org/download/devel/src/
 
 function get_versions_page() {
-    curl -s $releases_path
+    curl -s "$releases_path"
 }
 
 get_devel_versions_page() {
-    curl -s $devel_releases_path
+    curl -s "$devel_releases_path"
 }
 
 function extract_versions_numbers() {
@@ -18,7 +18,7 @@ append_devel_tag() {
     sed 's/$/-devel/g'
 }
 
-versions=$(get_versions_page | extract_versions_numbers)
-devel_versions=$(get_devel_versions_page | extract_versions_numbers | append_devel_tag)
+versions="$(get_versions_page | extract_versions_numbers)"
+devel_versions="$(get_devel_versions_page | extract_versions_numbers | append_devel_tag)"
 
-echo $devel_versions $versions | sort --version-sort
+echo -e "$devel_versions\n$versions" | sort --version-sort

--- a/bin/list-all
+++ b/bin/list-all
@@ -21,5 +21,5 @@ append_devel_tag() {
 versions="$(get_versions_page | extract_versions_numbers)"
 devel_versions="$(get_devel_versions_page | extract_versions_numbers | append_devel_tag)"
 
-echo -e "$devel_versions\n$versions" | sort --version-sort | uniq
+echo -e "$devel_versions\n$versions" | sort --version-sort | uniq | paste -s -d" " -
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -21,4 +21,4 @@ append_devel_tag() {
 versions=$(get_versions_page | extract_versions_numbers)
 devel_versions=$(get_devel_versions_page | extract_versions_numbers | append_devel_tag)
 
-echo $devel_versions $versions
+echo $devel_versions $versions | sort --version-sort

--- a/bin/list-all
+++ b/bin/list-all
@@ -21,4 +21,5 @@ append_devel_tag() {
 versions="$(get_versions_page | extract_versions_numbers)"
 devel_versions="$(get_devel_versions_page | extract_versions_numbers | append_devel_tag)"
 
-echo -e "$devel_versions\n$versions" | sort --version-sort
+echo -e "$devel_versions\n$versions" | sort --version-sort | uniq
+


### PR DESCRIPTION
This PR includes the following:
* Show releases with version numbers > 9
* Sort versions using `sort --version-sort`
* Apply suggestions from `shellcheck`