### PR TITLE
Use curl --compressed option to handle gzipped responses

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,11 +3,11 @@ releases_path=https://www.swi-prolog.org/download/stable/src/
 devel_releases_path=https://www.swi-prolog.org/download/devel/src/
 
 function get_versions_page() {
-    curl -s "$releases_path"
+    curl -s --compressed "$releases_path"
 }
 
 get_devel_versions_page() {
-    curl -s "$devel_releases_path"
+    curl -s --compressed "$devel_releases_path"
 }
 
 extract_versions_numbers() {


### PR DESCRIPTION
Currently `asdf-swiprolog` doesn't show stable versions anymore, as server started returning gzipped response and default curl invocation for me fails to parse it. The `--compressed` switch does nothing on uncompressed response. It seems that devel builds index are still returned uncompressed so it's a good test to ensure that both indices work.