### PR TITLE
Update install to work in dedicated build folder

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -57,11 +57,19 @@ curl -Lo "$source_path" "$download_url"
   # For versions after 7.7.21 use cmake instead of gnu autoconf tools
   # Here we compare versions without the '-devel' suffix (if any)
   if [[ "$(compare_version ${ASDF_INSTALL_VERSION%-devel} 7.7.21)" == '>' ]]; then
+    # Create an out-of-source build directory to satisfy CMake requirements
+    mkdir -p build
+    cd build
+    
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="$ASDF_INSTALL_PATH" \
       -DSWIPL_PACKAGES_X=OFF \
-      -DSWIPL_PACKAGES_JAVA=OFF
+      -DSWIPL_PACKAGES_JAVA=OFF \
+      ..
+      
+    make
+    make install
   else
     ./configure \
         --prefix="$ASDF_INSTALL_PATH" \
@@ -69,8 +77,8 @@ curl -Lo "$source_path" "$download_url"
         --without-jpl \
         --without-xpce \
         --disable-libdirversion
+        
+    make
+    make install
   fi
-
-  make
-  make install
 )


### PR DESCRIPTION
Hi,

I was having the following problem trying to install SWI Prolog `10.0.2` on a M2 Chip Macbook:

```sh
 ❯ mise use -g swiprolog@10.0

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

100 12.2M  100 12.2M    0     0  4069k      0  0:00:03  0:00:03 --:--:-- 6294k

CMake Warning:

  No source or binary directory provided.  Both will be assumed to be the

  same as the current working directory, but note that this warning will

  become a fatal error in future CMake releases.

CMake Error at CMakeLists.txt:11 (message):

   Can not build in the source directory.

   Please create a subdirectory and build in that directory.  E.g.

       mkdir build

       cd build

       cmake [option ...] ..

mise ERROR ~/.local/share/mise/plugins/swiprolog/bin/install failed

-- The C compiler identification is AppleClang 21.0.0.21000101

-- The CXX compiler identification is AppleClang 21.0.0.21000101

-- Detecting C compiler ABI info

-- Detecting C compiler ABI info - done

-- Check for working C compiler: /usr/bin/cc - skipped

-- Detecting C compile features

-- Detecting C compile features - done

-- Detecting CXX compiler ABI info

-- Detecting CXX compiler ABI info - done

-- Check for working CXX compiler: /usr/bin/c++ - skipped

-- Detecting CXX compile features

-- Detecting CXX compile features - done

-- Configuring incomplete, errors occurred!

swiprolog@10.0.2 -- Configuring incomplete, errors occurred!                                                                                                                                                                                                                                                                 ◜

mise ERROR Failed to install asdf:swiprolog@10.0: ~/.local/share/mise/plugins/swiprolog/bin/install exited with non-zero status: exit code 1

mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information 
```

Following is a fix that helped install `10.0.2` with no issues.
I am not sure whether this change breaks anything else.